### PR TITLE
Fix:	lowers the vibration intensity

### DIFF
--- a/recovery/root/init.recovery.qcom.rc
+++ b/recovery/root/init.recovery.qcom.rc
@@ -15,6 +15,8 @@ on fs
     write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
     write /sys/class/android_usb/android0/iProduct ${ro.product.model}
     write /sys/class/android_usb/android0/iSerial ${ro.serialno}
+    # Fix vibration_intensity
+    write /sys/class/timed_output/vibrator/play_mode direct
 
 on property:sys.usb.config=none
     write /sys/class/android_usb/android0/enable 0


### PR DESCRIPTION
Setting mode 'direct' instead of 'buffer' lowers the vibration intensity and makes it more comfortable.
See: https://usermanual.wiki/Pdf/80NM32853MSM8994LALINUXPMICHAPTICSSOFTWAREUSERGUIDE.985767111.pdf
